### PR TITLE
Add accessible zone entry calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Underfloor Heating Planner
+
+This project contains a small HTML5 application for planning underfloor heating layouts. It supports multiple floors, walls with angle and point snapping, draggable lines with editable lengths, rectangular distributors and polygonal zones assigned to distributors. The application can automatically route supply and return pipes from distributors to zones using horizontal and vertical segments that avoid walls when possible.
+The routing algorithm now estimates a search radius from the distributor to the furthest wall so that pipe paths stay within the building outline.
+
+Pipe routing checks if a direct path from a distributor to a zone edge is free of walls. When possible that straight route is used. Otherwise an A* search with a Manhattan heuristic finds the shortest axis-aligned route. The entry point is chosen by sampling points along the zone polygon and selecting the one with the shortest accessible path. After reaching this entry the pipes fill the zone in a serpentine pattern and return to the distributor.
+
+## Usage
+
+Open `index.html` in a modern web browser. A floor list is displayed to the left of the canvas. Use **Add Floor** to create new floors; click a floor in the list to view it or double‑click its name to rename it.
+The **Draw Wall** tool creates snapping lines. Use **Draw Zone** to trace around an area using multiple segments; when you finish back at the starting point the zone is created and you can enter its parameters. Use **Select/Move** to drag whole lines or their ends and edit their length in the **Line Length** input. Zones and distributors can also be moved with this tool. Double‑click a zone or distributor to change its properties or use the **Edit Distributor** button when a distributor is selected. Use **Delete Selected** (or press the Delete key) to remove the currently selected wall, zone or distributor.
+
+The grid is scaled so that 0.5 m corresponds to roughly 1 cm on screen. Adjust the grid size input if needed. Pipe spacing is entered in millimetres. Use the **Pan** tool to move the entire floor plan inside the canvas. Click **Draw Pipes** to automatically route supply and return pipes and fill each zone. **Clear** removes all items from the current floor.

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,54 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+}
+
+#main {
+    display: flex;
+}
+
+#floorPanel {
+    width: 180px;
+    margin-right: 10px;
+}
+
+#floorPanel button {
+    display: block;
+    margin-bottom: 5px;
+}
+
+#floorList {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    border: 1px solid #333;
+    height: 600px;
+    overflow-y: auto;
+}
+
+#floorList li {
+    padding: 4px 6px;
+    cursor: pointer;
+}
+
+#floorList li.selected {
+    background: #ddd;
+}
+
+#toolbar {
+    margin-bottom: 10px;
+}
+
+#toolbar button {
+    margin-right: 5px;
+}
+
+#toolbar input {
+    width: 60px;
+    margin-right: 5px;
+}
+
+#floorPlanCanvas {
+    border: 1px solid #333;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Underfloor Heating Planner</title>
+    <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+    <h1>Underfloor Heating Planner</h1>
+    <div id="main">
+        <div id="floorPanel">
+            <button id="addFloorBtn">Add Floor</button>
+            <ul id="floorList"></ul>
+        </div>
+        <div id="canvasPanel">
+            <div id="toolbar">
+                <button id="drawWallBtn">Draw Wall</button>
+                <button id="selectBtn">Select/Move</button>
+                <button id="panBtn">Pan</button>
+                <button id="drawZoneBtn">Draw Zone</button>
+                <button id="addDistributorBtn">Add Distributor</button>
+                <button id="editDistributorBtn">Edit Distributor</button>
+                <label>
+                    Grid Size:
+                    <input id="gridSize" type="number" value="38" min="10" step="1">
+                </label>
+                <label>
+                    Pipe Spacing (mm):
+                    <input id="pipeSpacing" type="number" value="300" min="10" step="10">
+                </label>
+                <label>
+                    Line Length:
+                    <input id="lineLength" type="number" step="1" disabled>
+                </label>
+                <button id="drawPipesBtn">Draw Pipes</button>
+                <button id="deleteBtn">Delete Selected</button>
+                <button id="clearBtn">Clear</button>
+            </div>
+            <canvas id="floorPlanCanvas" width="800" height="600"></canvas>
+        </div>
+    </div>
+    <script src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,832 @@
+window.addEventListener('load', () => {
+    const canvas = document.getElementById('floorPlanCanvas');
+    const ctx = canvas.getContext('2d');
+    const addFloorBtn = document.getElementById('addFloorBtn');
+    const floorList = document.getElementById('floorList');
+    const deleteBtn = document.getElementById('deleteBtn');
+    const drawWallBtn = document.getElementById('drawWallBtn');
+    const selectBtn = document.getElementById('selectBtn');
+    const drawZoneBtn = document.getElementById('drawZoneBtn');
+    const addDistributorBtn = document.getElementById('addDistributorBtn');
+    const editDistributorBtn = document.getElementById('editDistributorBtn');
+    const panBtn = document.getElementById('panBtn');
+    const clearBtn = document.getElementById('clearBtn');
+    const drawPipesBtn = document.getElementById('drawPipesBtn');
+    const spacingInput = document.getElementById('pipeSpacing');
+    const gridInput = document.getElementById('gridSize');
+    const lengthInput = document.getElementById('lineLength');
+
+    let gridSize = parseFloat(gridInput.value) || 38;
+    let pixelsPerMeter = gridSize * 2; // 0.5 m per grid square
+    let offsetX = 0;
+    let offsetY = 0;
+    let floors = [];
+    let currentFloor = null;
+    let mode = null;
+    let drawing = false;
+    let startX = 0;
+    let startY = 0;
+    let selectedWall = null;
+    let selectedZone = null;
+    let selectedDistributor = null;
+    let dragMode = null; // move, end1, end2 or moveZone/distributor
+    let zoneDrawing = null; // array of points while creating a zone
+
+    function addFloor(name) {
+        floors.push({
+            name,
+            walls: [],
+            zones: [],
+            distributors: []
+        });
+        currentFloor = floors[floors.length - 1];
+        updateFloorList();
+    }
+
+    function updateFloorList() {
+        floorList.innerHTML = '';
+        floors.forEach((f, idx) => {
+            const li = document.createElement('li');
+            li.textContent = f.name;
+            if (f === currentFloor) li.classList.add('selected');
+            li.addEventListener('click', () => {
+                currentFloor = f;
+                selectedWall = null;
+                selectedZone = null;
+                selectedDistributor = null;
+                updateFloorList();
+                drawAll();
+            });
+            li.addEventListener('dblclick', () => {
+                const n = prompt('Floor name?', f.name);
+                if (n) {
+                    f.name = n;
+                    updateFloorList();
+                }
+            });
+            floorList.appendChild(li);
+        });
+    }
+
+    addFloorBtn.addEventListener('click', () => {
+        const name = prompt('Floor name?', `Floor ${floors.length + 1}`);
+        if (name) {
+            addFloor(name);
+            drawAll();
+        }
+    });
+
+    drawWallBtn.addEventListener('click', () => {
+        mode = 'wall';
+    });
+
+    selectBtn.addEventListener('click', () => {
+        mode = 'select';
+        selectedWall = null;
+        lengthInput.value = '';
+        lengthInput.disabled = true;
+        drawAll();
+    });
+
+    drawZoneBtn.addEventListener('click', () => {
+        mode = 'zone';
+    });
+
+    addDistributorBtn.addEventListener('click', () => {
+        mode = 'distributor';
+    });
+
+    editDistributorBtn.addEventListener('click', () => {
+        if (selectedDistributor) {
+            const width = parseFloat(prompt('Width (m)?', (selectedDistributor.width/pixelsPerMeter).toFixed(2)), 10);
+            const height = parseFloat(prompt('Height (m)?', (selectedDistributor.height/pixelsPerMeter).toFixed(2)), 10);
+            const name = prompt('Name?', selectedDistributor.name) || selectedDistributor.name;
+            const connections = parseInt(prompt('Connections?', selectedDistributor.connections), 10);
+            if (!isNaN(width)) selectedDistributor.width = width * pixelsPerMeter;
+            if (!isNaN(height)) selectedDistributor.height = height * pixelsPerMeter;
+            if (!isNaN(connections)) selectedDistributor.connections = connections;
+            selectedDistributor.name = name;
+            drawAll();
+        }
+    });
+
+    panBtn.addEventListener('click', () => {
+        mode = 'pan';
+    });
+
+    function deleteSelected() {
+        if (!currentFloor) return;
+        if (selectedWall) {
+            const i = currentFloor.walls.indexOf(selectedWall);
+            if (i >= 0) currentFloor.walls.splice(i, 1);
+            selectedWall = null;
+            lengthInput.value = '';
+        } else if (selectedZone) {
+            const i = currentFloor.zones.indexOf(selectedZone);
+            if (i >= 0) currentFloor.zones.splice(i, 1);
+            selectedZone = null;
+        } else if (selectedDistributor) {
+            const i = currentFloor.distributors.indexOf(selectedDistributor);
+            if (i >= 0) currentFloor.distributors.splice(i, 1);
+            selectedDistributor = null;
+        }
+        drawAll();
+    }
+
+    deleteBtn.addEventListener('click', deleteSelected);
+
+    document.addEventListener('keydown', e => {
+        if (e.key === 'Delete') {
+            deleteSelected();
+        }
+    });
+
+    clearBtn.addEventListener('click', () => {
+        if (!currentFloor) return;
+        currentFloor.walls = [];
+        currentFloor.zones = [];
+        currentFloor.distributors = [];
+        selectedWall = null;
+        selectedZone = null;
+        selectedDistributor = null;
+        drawAll();
+    });
+
+    gridInput.addEventListener('change', () => {
+        gridSize = parseFloat(gridInput.value) || 38;
+        pixelsPerMeter = gridSize * 2;
+        drawAll();
+    });
+
+    lengthInput.addEventListener('change', () => {
+        if (!selectedWall) return;
+        const len = parseFloat(lengthInput.value);
+        if (isNaN(len)) return;
+        const target = len * pixelsPerMeter;
+        const dx = selectedWall.x2 - selectedWall.x1;
+        const dy = selectedWall.y2 - selectedWall.y1;
+        const current = Math.hypot(dx, dy) || 1;
+        const factor = target / current;
+        selectedWall.x2 = selectedWall.x1 + dx * factor;
+        selectedWall.y2 = selectedWall.y1 + dy * factor;
+        drawAll();
+    });
+
+    function drawGrid() {
+        ctx.strokeStyle = '#ccc';
+        ctx.beginPath();
+        for (let x = -offsetX % gridSize; x <= canvas.width; x += gridSize) {
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, canvas.height);
+        }
+        for (let y = -offsetY % gridSize; y <= canvas.height; y += gridSize) {
+            ctx.moveTo(0, y);
+            ctx.lineTo(canvas.width, y);
+        }
+        ctx.stroke();
+    }
+
+    function drawAll() {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.save();
+        ctx.translate(offsetX, offsetY);
+        drawGrid();
+        if (!currentFloor) return;
+        ctx.strokeStyle = '#000';
+        // walls
+        currentFloor.walls.forEach(w => {
+            ctx.strokeStyle = (w === selectedWall) ? 'red' : '#000';
+            ctx.beginPath();
+            ctx.moveTo(w.x1, w.y1);
+            ctx.lineTo(w.x2, w.y2);
+            ctx.stroke();
+        });
+        ctx.strokeStyle = '#000';
+        // zones
+        currentFloor.zones.forEach(z => {
+            ctx.beginPath();
+            ctx.moveTo(z.points[0].x, z.points[0].y);
+            for (let i = 1; i < z.points.length; i++) {
+                ctx.lineTo(z.points[i].x, z.points[i].y);
+            }
+            ctx.closePath();
+            ctx.fillStyle = z === selectedZone ? 'rgba(0,255,0,0.3)' : 'rgba(0,255,0,0.1)';
+            ctx.fill();
+            ctx.strokeStyle = z === selectedZone ? 'red' : '#000';
+            ctx.stroke();
+            if (z.name) {
+                const b = zoneBounds(z);
+                ctx.fillStyle = '#000';
+                ctx.fillText(z.name, b.x + 4, b.y + 12);
+            }
+        });
+        if (zoneDrawing && mode === 'zone') {
+            ctx.beginPath();
+            ctx.moveTo(zoneDrawing[0].x, zoneDrawing[0].y);
+            for (let i = 1; i < zoneDrawing.length; i++) {
+                ctx.lineTo(zoneDrawing[i].x, zoneDrawing[i].y);
+            }
+            ctx.strokeStyle = 'red';
+            ctx.stroke();
+        }
+        // distributors
+        ctx.fillStyle = 'rgba(0,0,255,0.3)';
+        currentFloor.distributors.forEach(d => {
+            ctx.fillStyle = d === selectedDistributor ? 'rgba(0,0,255,0.5)' : 'rgba(0,0,255,0.3)';
+            ctx.fillRect(d.x - d.width / 2, d.y - d.height / 2, d.width, d.height);
+            ctx.strokeStyle = d === selectedDistributor ? 'red' : '#000';
+            ctx.strokeRect(d.x - d.width / 2, d.y - d.height / 2, d.width, d.height);
+            if (d.name) {
+                ctx.fillStyle = '#000';
+                ctx.fillText(d.name, d.x - d.width / 2 + 2, d.y - d.height / 2 + 12);
+            }
+        });
+        ctx.restore();
+    }
+
+    function pathLength(path) {
+        let len = 0;
+        for (let i = 0; i < path.length - 1; i++) {
+            const dx = path[i + 1].x - path[i].x;
+            const dy = path[i + 1].y - path[i].y;
+            len += Math.hypot(dx, dy);
+        }
+        return len;
+    }
+
+    function closestAccessiblePoint(zone, distributor) {
+        const step = gridSize;
+        let best = zone.points[0];
+        let bestLen = Infinity;
+        const start = { x: distributor.x, y: distributor.y };
+        for (let i = 0; i < zone.points.length; i++) {
+            const p1 = zone.points[i];
+            const p2 = zone.points[(i + 1) % zone.points.length];
+            const segLen = Math.hypot(p2.x - p1.x, p2.y - p1.y);
+            const samples = Math.max(1, Math.ceil(segLen / step));
+            for (let s = 0; s <= samples; s++) {
+                const t = s / samples;
+                const candidate = {
+                    x: p1.x + (p2.x - p1.x) * t,
+                    y: p1.y + (p2.y - p1.y) * t
+                };
+                const path = findPath(start, candidate);
+                const d = pathLength(path);
+                if (d < bestLen) {
+                    bestLen = d;
+                    best = candidate;
+                }
+            }
+        }
+        return best;
+    }
+
+    function drawPipes() {
+        drawAll();
+        if (!currentFloor) return;
+        ctx.save();
+        ctx.translate(offsetX, offsetY);
+        currentFloor.zones.forEach(zone => {
+            const rect = zoneBounds(zone);
+            const defSpacing = (parseInt(spacingInput.value, 10) || 0) / 1000 * pixelsPerMeter;
+            const spacing = zone.spacing || defSpacing || gridSize;
+            const dist = currentFloor.distributors[zone.distributorId || 0];
+            if (!dist) return;
+
+            const entry = closestAccessiblePoint(zone, dist);
+            const path = findPath({ x: dist.x, y: dist.y }, entry);
+            drawPipePath(path, 'red', 0);
+            drawZonePattern(rect, spacing, entry);
+            const returnPath = findPath(entry, { x: dist.x, y: dist.y });
+            drawPipePath(returnPath, 'blue', 4);
+        });
+        ctx.restore();
+    }
+
+    const SNAP_DIST = 10;
+
+    function snapAngle(dx, dy) {
+        const angle = Math.atan2(dy, dx);
+        const snap = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+        let result = angle;
+        if (Math.abs(angle - snap) < Math.PI / 18) { // ~10 degrees
+            result = snap;
+        }
+        const len = Math.sqrt(dx * dx + dy * dy);
+        return {
+            dx: Math.cos(result) * len,
+            dy: Math.sin(result) * len
+        };
+    }
+
+    function snapToPoints(x, y) {
+        let sx = x, sy = y;
+        currentFloor.walls.forEach(w => {
+            const points = [
+                {x: w.x1, y: w.y1},
+                {x: w.x2, y: w.y2},
+                {x: (w.x1 + w.x2) / 2, y: (w.y1 + w.y2) / 2}
+            ];
+            points.forEach(p => {
+                if (Math.hypot(p.x - x, p.y - y) < SNAP_DIST) {
+                    sx = p.x;
+                    sy = p.y;
+                }
+            });
+        });
+        currentFloor.zones.forEach(z => {
+            z.points.forEach(p => {
+                if (Math.hypot(p.x - x, p.y - y) < SNAP_DIST) {
+                    sx = p.x;
+                    sy = p.y;
+                }
+            });
+        });
+        return {x: sx, y: sy};
+    }
+
+    function wallLength(w) {
+        return Math.hypot(w.x2 - w.x1, w.y2 - w.y1);
+    }
+
+    function wallLengthMeters(w) {
+        return wallLength(w) / pixelsPerMeter;
+    }
+
+    function hitTestWall(x, y) {
+        for (let i = currentFloor.walls.length - 1; i >= 0; i--) {
+            const w = currentFloor.walls[i];
+            if (Math.hypot(w.x1 - x, w.y1 - y) < SNAP_DIST) {
+                return {wall: w, mode: 'end1'};
+            }
+            if (Math.hypot(w.x2 - x, w.y2 - y) < SNAP_DIST) {
+                return {wall: w, mode: 'end2'};
+            }
+            const dist = distanceToSegment(x, y, w.x1, w.y1, w.x2, w.y2);
+            if (dist < SNAP_DIST) {
+                return {wall: w, mode: 'move'};
+            }
+        }
+        return {wall: null};
+    }
+
+    function distanceToSegment(px, py, x1, y1, x2, y2) {
+        const dx = x2 - x1;
+        const dy = y2 - y1;
+        const lenSq = dx * dx + dy * dy;
+        let t = ((px - x1) * dx + (py - y1) * dy) / lenSq;
+        t = Math.max(0, Math.min(1, t));
+        const lx = x1 + t * dx;
+        const ly = y1 + t * dy;
+        return Math.hypot(px - lx, py - ly);
+    }
+
+    function zoneBounds(z) {
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        z.points.forEach(p => {
+            if (p.x < minX) minX = p.x;
+            if (p.y < minY) minY = p.y;
+            if (p.x > maxX) maxX = p.x;
+            if (p.y > maxY) maxY = p.y;
+        });
+        return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+    }
+
+    function pointInPolygon(x, y, poly) {
+        let inside = false;
+        for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+            const xi = poly[i].x, yi = poly[i].y;
+            const xj = poly[j].x, yj = poly[j].y;
+            const intersect = ((yi > y) !== (yj > y)) &&
+                (x < (xj - xi) * (y - yi) / (yj - yi) + xi);
+            if (intersect) inside = !inside;
+        }
+        return inside;
+    }
+
+    function segmentsIntersect(ax1, ay1, ax2, ay2, bx1, by1, bx2, by2) {
+        function ccw(x1, y1, x2, y2, x3, y3) {
+            return (y3 - y1) * (x2 - x1) > (y2 - y1) * (x3 - x1);
+        }
+        return (ccw(ax1, ay1, bx1, by1, bx2, by2) !== ccw(ax2, ay2, bx1, by1, bx2, by2)) &&
+               (ccw(ax1, ay1, ax2, ay2, bx1, by1) !== ccw(ax1, ay1, ax2, ay2, bx2, by2));
+    }
+
+    function segmentIntersectsWall(x1, y1, x2, y2) {
+        return currentFloor.walls.some(w =>
+            segmentsIntersect(x1, y1, x2, y2, w.x1, w.y1, w.x2, w.y2)
+        );
+    }
+
+    function floorBounds() {
+        if (!currentFloor || currentFloor.walls.length === 0) {
+            return { minX: -1000, maxX: 1000, minY: -1000, maxY: 1000 };
+        }
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        currentFloor.walls.forEach(w => {
+            minX = Math.min(minX, w.x1, w.x2);
+            minY = Math.min(minY, w.y1, w.y2);
+            maxX = Math.max(maxX, w.x1, w.x2);
+            maxY = Math.max(maxY, w.y1, w.y2);
+        });
+        return { minX, maxX, minY, maxY };
+    }
+
+    function farthestWallDistance(pt) {
+        const b = floorBounds();
+        const corners = [
+            { x: b.minX, y: b.minY },
+            { x: b.minX, y: b.maxY },
+            { x: b.maxX, y: b.minY },
+            { x: b.maxX, y: b.maxY }
+        ];
+        let max = 0;
+        corners.forEach(c => {
+            const d = Math.hypot(c.x - pt.x, c.y - pt.y);
+            if (d > max) max = d;
+        });
+        return max;
+    }
+
+    function lineClear(a, b) {
+        return !segmentIntersectsWall(a.x, a.y, b.x, b.y);
+    }
+
+    function simplifyPath(path) {
+        if (path.length <= 2) return path;
+        const out = [path[0]];
+        let prevDx = path[1].x - path[0].x;
+        let prevDy = path[1].y - path[0].y;
+        for (let i = 1; i < path.length - 1; i++) {
+            const dx = path[i + 1].x - path[i].x;
+            const dy = path[i + 1].y - path[i].y;
+            if (dx * prevDy !== dy * prevDx) {
+                out.push(path[i]);
+                prevDx = dx;
+                prevDy = dy;
+            }
+        }
+        out.push(path[path.length - 1]);
+        return out;
+    }
+
+    function findPath(start, end) {
+        const step = gridSize;
+        const bounds = floorBounds();
+        if (lineClear(start, end)) return [start, end];
+        const limit = farthestWallDistance(start) + step * 4;
+        const sx = Math.round(start.x / step) * step;
+        const sy = Math.round(start.y / step) * step;
+        const gx = Math.round(end.x / step) * step;
+        const gy = Math.round(end.y / step) * step;
+        const open = [{ x: sx, y: sy, g: 0, path: [{ x: start.x, y: start.y }] }];
+        const visited = new Set([`${sx},${sy}`]);
+        const dirs = [ [step,0], [-step,0], [0,step], [0,-step] ];
+        function heuristic(x,y) { return Math.abs(x - gx) + Math.abs(y - gy); }
+        while (open.length) {
+            open.sort((a,b)=> (a.g + heuristic(a.x,a.y)) - (b.g + heuristic(b.x,b.y)));
+            const n = open.shift();
+            if (n.x === gx && n.y === gy) {
+                n.path.push({ x: end.x, y: end.y });
+                return simplifyPath(n.path);
+            }
+            for (const [dx, dy] of dirs) {
+                const nx = n.x + dx;
+                const ny = n.y + dy;
+                const key = `${nx},${ny}`;
+                if (visited.has(key)) continue;
+                if (segmentIntersectsWall(n.x, n.y, nx, ny)) continue;
+                if (nx < bounds.minX - step || nx > bounds.maxX + step || ny < bounds.minY - step || ny > bounds.maxY + step)
+                    continue;
+                if (Math.hypot(nx - start.x, ny - start.y) > limit)
+                    continue;
+                visited.add(key);
+                open.push({ x: nx, y: ny, g: n.g + step, path: n.path.concat([{ x: nx, y: ny }]) });
+            }
+        }
+        return [start, end];
+    }
+
+    function drawPipePath(path, color, offset) {
+        ctx.strokeStyle = color;
+        for (let i = 0; i < path.length - 1; i++) {
+            const p1 = path[i];
+            const p2 = path[i + 1];
+            const dx = p2.x - p1.x;
+            const dy = p2.y - p1.y;
+            const len = Math.hypot(dx, dy) || 1;
+            const ox = -dy / len * offset;
+            const oy = dx / len * offset;
+            ctx.beginPath();
+            ctx.moveTo(p1.x + ox, p1.y + oy);
+            ctx.lineTo(p2.x + ox, p2.y + oy);
+            ctx.stroke();
+        }
+    }
+
+    function drawZonePattern(rect, spacing, entry) {
+        ctx.strokeStyle = 'orange';
+        const startDir = entry.x <= rect.x + rect.width / 2;
+        let leftToRight = startDir;
+        let y = Math.max(rect.y + spacing / 2,
+                         Math.min(entry.y, rect.y + rect.height - spacing / 2));
+        for (; y < rect.y + rect.height; y += spacing) {
+            ctx.beginPath();
+            if (leftToRight) {
+                ctx.moveTo(rect.x, y);
+                ctx.lineTo(rect.x + rect.width, y);
+            } else {
+                ctx.moveTo(rect.x + rect.width, y);
+                ctx.lineTo(rect.x, y);
+            }
+            ctx.stroke();
+            leftToRight = !leftToRight;
+        }
+        leftToRight = !startDir;
+        for (y = y - spacing * 2; y >= rect.y; y -= spacing) {
+            ctx.beginPath();
+            if (leftToRight) {
+                ctx.moveTo(rect.x, y);
+                ctx.lineTo(rect.x + rect.width, y);
+            } else {
+                ctx.moveTo(rect.x + rect.width, y);
+                ctx.lineTo(rect.x, y);
+            }
+            ctx.stroke();
+            leftToRight = !leftToRight;
+        }
+    }
+
+    function screenToWorld(x, y) {
+        return { x: x - offsetX, y: y - offsetY };
+    }
+
+    function hitTestZone(x, y) {
+        for (let i = currentFloor.zones.length - 1; i >= 0; i--) {
+            const r = currentFloor.zones[i];
+            if (pointInPolygon(x, y, r.points)) {
+                return r;
+            }
+        }
+        return null;
+    }
+
+    function hitTestDistributor(x, y) {
+        for (let i = currentFloor.distributors.length - 1; i >= 0; i--) {
+            const d = currentFloor.distributors[i];
+            if (x >= d.x - d.width / 2 && x <= d.x + d.width / 2 &&
+                y >= d.y - d.height / 2 && y <= d.y + d.height / 2) {
+                return d;
+            }
+        }
+        return null;
+    }
+
+    canvas.addEventListener('mousedown', e => {
+        if (!currentFloor) return;
+        const rect = canvas.getBoundingClientRect();
+        const sx = e.clientX - rect.left;
+        const sy = e.clientY - rect.top;
+        const world = screenToWorld(sx, sy);
+        if (mode === 'pan') {
+            startX = sx;
+            startY = sy;
+            drawing = true;
+            return;
+        }
+        startX = world.x;
+        startY = world.y;
+        if (mode === 'wall') {
+            drawing = true;
+        } else if (mode === 'zone') {
+            const snap = snapToPoints(startX, startY);
+            if (!zoneDrawing) {
+                zoneDrawing = [snap];
+            }
+            startX = zoneDrawing[zoneDrawing.length - 1].x;
+            startY = zoneDrawing[zoneDrawing.length - 1].y;
+            drawing = true;
+        } else if (mode === 'distributor') {
+            const width = parseFloat(prompt('Width (m)?', '0.3')) || 0.3;
+            const height = parseFloat(prompt('Height (m)?', '0.1')) || 0.1;
+            const pxWidth = width * pixelsPerMeter;
+            const pxHeight = height * pixelsPerMeter;
+            const name = prompt('Name?', `D${currentFloor.distributors.length + 1}`) || '';
+            const connections = parseInt(prompt('Connections?', '2'), 10) || 2;
+            currentFloor.distributors.push({ x: startX, y: startY, width: pxWidth, height: pxHeight, name, connections });
+            drawAll();
+        } else if (mode === 'select') {
+            const hit = hitTestWall(startX, startY);
+            if (hit.wall) {
+                selectedWall = hit.wall;
+                selectedZone = null;
+                selectedDistributor = null;
+                dragMode = hit.mode;
+                drawing = true;
+                lengthInput.disabled = false;
+                lengthInput.value = wallLengthMeters(selectedWall).toFixed(2);
+            } else {
+                selectedWall = null;
+                lengthInput.value = '';
+                lengthInput.disabled = true;
+                const r = hitTestZone(startX, startY);
+                const d = hitTestDistributor(startX, startY);
+                if (r) {
+                    selectedZone = r;
+                    selectedDistributor = null;
+                    dragMode = 'moveZone';
+                    drawing = true;
+                } else if (d) {
+                    selectedDistributor = d;
+                    selectedZone = null;
+                    dragMode = 'moveDistributor';
+                    drawing = true;
+                } else {
+                    selectedZone = null;
+                    selectedDistributor = null;
+                    drawAll();
+                }
+            }
+        }
+    });
+
+    canvas.addEventListener('mousemove', e => {
+        if (!drawing) return;
+        const rect = canvas.getBoundingClientRect();
+        const sx = e.clientX - rect.left;
+        const sy = e.clientY - rect.top;
+        const pos = screenToWorld(sx, sy);
+        const x = pos.x;
+        const y = pos.y;
+        if (mode === 'pan') {
+            const dx = sx - startX;
+            const dy = sy - startY;
+            offsetX += dx;
+            offsetY += dy;
+            startX = sx;
+            startY = sy;
+            drawAll();
+            return;
+        }
+        drawAll();
+        if (mode === 'wall') {
+            const snap = snapAngle(x - startX, y - startY);
+            const snapped = snapToPoints(startX + snap.dx, startY + snap.dy);
+            ctx.strokeStyle = 'red';
+            ctx.beginPath();
+            ctx.moveTo(startX, startY);
+            ctx.lineTo(snapped.x, snapped.y);
+            ctx.stroke();
+        } else if (mode === 'zone') {
+            if (!zoneDrawing) return;
+            ctx.strokeStyle = 'red';
+            const snap = snapToPoints(x, y);
+            ctx.beginPath();
+            ctx.moveTo(zoneDrawing[0].x, zoneDrawing[0].y);
+            for (let i = 1; i < zoneDrawing.length; i++) {
+                ctx.lineTo(zoneDrawing[i].x, zoneDrawing[i].y);
+            }
+            ctx.lineTo(snap.x, snap.y);
+            ctx.stroke();
+        } else if (mode === 'select' && selectedWall) {
+            if (dragMode === 'move') {
+                const dx = x - startX;
+                const dy = y - startY;
+                selectedWall.x1 += dx;
+                selectedWall.y1 += dy;
+                selectedWall.x2 += dx;
+                selectedWall.y2 += dy;
+                startX = x;
+                startY = y;
+                lengthInput.value = wallLengthMeters(selectedWall).toFixed(2);
+                drawAll();
+            } else if (dragMode === 'end1' || dragMode === 'end2') {
+                const anchorX = dragMode === 'end1' ? selectedWall.x2 : selectedWall.x1;
+                const anchorY = dragMode === 'end1' ? selectedWall.y2 : selectedWall.y1;
+                const snap = snapAngle(x - anchorX, y - anchorY);
+                const snapped = snapToPoints(anchorX + snap.dx, anchorY + snap.dy);
+                if (dragMode === 'end1') {
+                    selectedWall.x1 = snapped.x;
+                    selectedWall.y1 = snapped.y;
+                } else {
+                    selectedWall.x2 = snapped.x;
+                    selectedWall.y2 = snapped.y;
+                }
+                lengthInput.value = wallLengthMeters(selectedWall).toFixed(2);
+                drawAll();
+            }
+        } else if (mode === 'select' && selectedZone && dragMode === 'moveZone') {
+            const dx = x - startX;
+            const dy = y - startY;
+            selectedZone.points.forEach(p => {
+                p.x += dx;
+                p.y += dy;
+            });
+            startX = x;
+            startY = y;
+            drawAll();
+        } else if (mode === 'select' && selectedDistributor && dragMode === 'moveDistributor') {
+            const dx = x - startX;
+            const dy = y - startY;
+            selectedDistributor.x += dx;
+            selectedDistributor.y += dy;
+            startX = x;
+            startY = y;
+            drawAll();
+        }
+    });
+
+    canvas.addEventListener('mouseup', e => {
+        if (!drawing) return;
+        drawing = false;
+        const rect = canvas.getBoundingClientRect();
+        const sx = e.clientX - rect.left;
+        const sy = e.clientY - rect.top;
+        const pos = screenToWorld(sx, sy);
+        const x = pos.x;
+        const y = pos.y;
+        if (mode === 'pan') {
+            return;
+        }
+        if (mode === 'wall') {
+            const snap = snapAngle(x - startX, y - startY);
+            const snapped = snapToPoints(startX + snap.dx, startY + snap.dy);
+            currentFloor.walls.push({
+                x1: startX,
+                y1: startY,
+                x2: snapped.x,
+                y2: snapped.y
+            });
+        } else if (mode === 'zone') {
+            if (!zoneDrawing) return;
+            const snap = snapToPoints(x, y);
+            const first = zoneDrawing[0];
+            if (zoneDrawing.length >= 2 && Math.hypot(snap.x - first.x, snap.y - first.y) < SNAP_DIST) {
+                // close polygon
+                const name = prompt('Zone name?', `Zone ${currentFloor.zones.length + 1}`) || '';
+                const spacingMm = parseInt(prompt('Pipe spacing (mm)?', spacingInput.value), 10) || parseInt(spacingInput.value, 10) || 0;
+                const spacing = spacingMm / 1000 * pixelsPerMeter;
+                let distributorId = null;
+                if (currentFloor.distributors.length > 0) {
+                    const list = currentFloor.distributors.map((d,i) => `${i}: ${d.name}`).join('\n');
+                    const ans = prompt('Distributor index:\n' + list, '0');
+                    const idx = parseInt(ans, 10);
+                    if (!isNaN(idx) && currentFloor.distributors[idx]) distributorId = idx;
+                }
+                const points = zoneDrawing.slice();
+                currentFloor.zones.push({ points, name, spacing, distributorId });
+                zoneDrawing = null;
+            } else {
+                zoneDrawing.push(snap);
+                startX = snap.x;
+                startY = snap.y;
+                drawing = false;
+                drawAll();
+                return;
+            }
+        } else if (mode === 'select') {
+            lengthInput.value = selectedWall ? wallLengthMeters(selectedWall).toFixed(2) : '';
+        }
+        dragMode = null;
+        drawAll();
+    });
+
+    drawPipesBtn.addEventListener('click', drawPipes);
+
+    canvas.addEventListener('dblclick', e => {
+        if (!currentFloor) return;
+        const rect = canvas.getBoundingClientRect();
+        const sx = e.clientX - rect.left;
+        const sy = e.clientY - rect.top;
+        const pos = screenToWorld(sx, sy);
+        const x = pos.x;
+        const y = pos.y;
+        const r = hitTestZone(x, y);
+        const d = hitTestDistributor(x, y);
+        if (r) {
+            r.name = prompt('Zone name?', r.name || '') || r.name;
+            const spacingMm = parseInt(prompt('Pipe spacing (mm)?', Math.round(r.spacing / pixelsPerMeter * 1000)), 10);
+            if (!isNaN(spacingMm)) r.spacing = spacingMm / 1000 * pixelsPerMeter;
+            if (currentFloor.distributors.length > 0) {
+                const list = currentFloor.distributors.map((d,i)=>`${i}: ${d.name}`).join('\n');
+                const ans = prompt('Distributor index:\n' + list, r.distributorId ?? '');
+                const idx = parseInt(ans, 10);
+                if (!isNaN(idx) && currentFloor.distributors[idx]) r.distributorId = idx;
+            }
+            drawAll();
+        } else if (d) {
+            d.name = prompt('Name?', d.name || '') || d.name;
+            const width = parseFloat(prompt('Width (m)?', (d.width/pixelsPerMeter).toFixed(2)), 10);
+            const height = parseFloat(prompt('Height (m)?', (d.height/pixelsPerMeter).toFixed(2)), 10);
+            const connections = parseInt(prompt('Connections?', d.connections), 10);
+            if (!isNaN(width)) d.width = width * pixelsPerMeter;
+            if (!isNaN(height)) d.height = height * pixelsPerMeter;
+            if (!isNaN(connections)) d.connections = connections;
+            drawAll();
+        }
+    });
+
+    // initialise with one floor
+    addFloor('Floor 1');
+    drawAll();
+});


### PR DESCRIPTION
## Summary
- add `closestAccessiblePoint` and supporting `pathLength`
- use entry point for routing and drawing the serpentine pattern
- update README description of the routing algorithm

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a8f66f0a88324866fa9c039af7abb